### PR TITLE
feat: optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ const cropOptions = {
 </Upload>
 ```
 
+### Compress Image
+
+check all compress options [here](https://github.com/Donaldcwl/browser-image-compression)
+
+```js
+const compressOptions = {
+  maxSizeMB: 0.5,
+};
+
+<Upload ossOptions={ossOptions} compressOptions={compressOptions}>
+  <Button>upload</Button>
+</Upload>
+```
+
 check full examples [here](./example/src/app.js)
 
 
@@ -83,10 +97,11 @@ some extra options are list below
 | Property | Description | Type | Default |
 |------------|--------------|-------------|--------------|
 | ossOptions | [ali-oss](https://github.com/ali-sdk/ali-oss) options, required | object | - |
-| cropOptions |	crop option from [react-image-crop](https://github.com/DominicTobias/react-image-crop#readme) | object | - |
+| cropOptions |	crop options from [react-image-crop](https://github.com/DominicTobias/react-image-crop) | object | - |
+| compressOptions | compress options from [browser-image-compression](https://github.com/Donaldcwl/browser-image-compression) options | object | - |
 | max | the max size of file list | number | - |
 | value | initial file list | array | - |
-| onChange | A callback function, can be executed when uploading state is changing | Function | - |
+| onChange | A callback function, can be executed when uploading state is changing | function | - |
 
 
 

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -29,6 +29,12 @@ class App extends Component {
     };
   }
 
+  get compressOptions() {
+    return {
+      maxSizeMB: 0.5,
+    };
+  }
+
   onSubmit = () => {
     const upload = this.props.form.getFieldValue("upload");
     console.log(upload);
@@ -69,6 +75,14 @@ class App extends Component {
 
         <Divider orientation="left">Crop Before Upload</Divider>
         <Upload ossOptions={this.ossOptions} cropOptions={this.cropOptions}>
+          <Button>upload</Button>
+        </Upload>
+
+        <Divider orientation="left">Limit Image Size (0.5MB)</Divider>
+        <Upload
+          ossOptions={this.ossOptions}
+          compressOptions={this.compressOptions}
+        >
           <Button>upload</Button>
         </Upload>
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     ]
   },
   "dependencies": {
+    "browser-image-compression": "^1.0.6",
     "lodash": "^4.17.11",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "browser-image-compression": "^1.0.6",
+    "jsdom-worker-fix": "^0.1.8",
     "lodash": "^4.17.11",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
@@ -78,5 +79,10 @@
   "peerDependencies": {
     "ali-oss": "^6.1.1",
     "antd": "^3.20.3"
+  },
+  "jest": {
+    "setupFiles": [
+      "jsdom-worker-fix"
+    ]
   }
 }

--- a/src/crop.js
+++ b/src/crop.js
@@ -20,6 +20,9 @@ export default class Crop extends React.Component {
     return new Promise((resolve, reject) => {
       Modal.confirm({
         width: "max-content",
+        style: {
+          maxWidth: "1000px",
+        },
         icon: " ",
         content: <Crop file={file} options={options} />,
         onOk: () => {
@@ -54,8 +57,8 @@ export default class Crop extends React.Component {
     const canvas = document.createElement("canvas");
     const scaleX = image.naturalWidth / image.width;
     const scaleY = image.naturalHeight / image.height;
-    canvas.width = crop.width;
-    canvas.height = crop.height;
+    canvas.width = crop.width * scaleX;
+    canvas.height = crop.height * scaleY;
     const ctx = canvas.getContext("2d");
 
     ctx.drawImage(
@@ -66,8 +69,8 @@ export default class Crop extends React.Component {
       crop.height * scaleY,
       0,
       0,
-      crop.width,
-      crop.height
+      crop.width * scaleX,
+      crop.height * scaleY
     );
 
     return new Promise((resolve, reject) => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Upload } from "antd";
 import isEqual from "lodash/isEqual";
 import OSS from "ali-oss";
+import imageCompression from "browser-image-compression";
 
 import Crop from "./crop";
 
@@ -44,10 +45,17 @@ export default class UploadComponent extends React.Component {
   };
 
   beforeUpload = async file => {
-    const { cropOptions } = this.props;
+    const { cropOptions, compressOptions } = this.props;
     let blob = file;
     if (cropOptions) {
       blob = await Crop.crop(file, cropOptions);
+      blob.uid = file.uid;
+      blob.lastModifiedDate = file.lastModifiedDate;
+      blob.lastModified = file.lastModified;
+    }
+
+    if (compressOptions) {
+      blob = await imageCompression(blob, compressOptions);
       blob.uid = file.uid;
       blob.lastModifiedDate = file.lastModifiedDate;
       blob.lastModified = file.lastModified;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,11 @@ brotli-size@^0.0.3:
     duplexer "^0.1.1"
     iltorb "^2.0.5"
 
+browser-image-compression@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-1.0.6.tgz#3d710aea5a6bb1cb6804737418fceb8a527e79f2"
+  integrity sha512-gb++v1g26BgV/I9qrdXNzirFLDGcOiPmobVxuTJymNTFHbbxJnZ74o1GRoYHjDTgOt1Iypqh4Wk1K03C8tjXHQ==
+
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8982,6 +8982,14 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jsdom-worker-fix@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/jsdom-worker-fix/-/jsdom-worker-fix-0.1.8.tgz#2cd92b5e1b3e3f9e9b419b30f96f507525733949"
+  integrity sha512-hkbmlBkj66MkSIx3NywyO8lOOpzdleSBz+BaKaL4O4b9feIt1mSYLRl5D1RlbfvQ32OqXuukDNucrftMmkdSfw==
+  dependencies:
+    mitt "^1.1.3"
+    uuid-v4 "^0.1.0"
+
 jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
@@ -10256,6 +10264,11 @@ mississippi@^3.0.0:
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
+
+mitt@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.3.tgz#528c506238a05dce11cd914a741ea2cc332da9b8"
+  integrity sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -16171,6 +16184,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid-v4@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/uuid-v4/-/uuid-v4-0.1.0.tgz#62d7b310406f6cecfea1528c69f1e8e0bcec5a3a"
+  integrity sha1-YtezEEBvbOz+oVKMafHo4LzsWjo=
 
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
### 对应的 Issue

Issue(#2 )

### 修改内容

1. 能限制上传图片的大小，自动压缩图片
2. 优化裁剪弹窗的大小

### 其他

1.  组件本身支持 antd upload 的所有配置项，所以需求中的 2 3 4 5 均已经支持，参考 https://github.com/zzswang/life-admin/blob/master/src/components/upload/single-upload.js

2. 找不到能支持拖动背景图片的裁剪组件，暂时先维持原样