### PR TITLE
feat: support preview filetypes in addition to image

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,26 @@
 import React from "react";
-import { Upload, message, Modal } from "antd";
+import { Upload, message, Modal, Icon } from "antd";
 import isEqual from "lodash/isEqual";
 import OSS from "ali-oss";
 import PropTypes from "prop-types";
 
 import Crop from "./crop";
+
+const PREVIEW_CONTENT = {
+  video: src => (
+    <video width="400" controls>
+      <source src={src} />
+      Your browser does not support HTML5 video.
+    </video>
+  ),
+  img: src => <img alt="example" style={{ width: "100%" }} src={src} />,
+  file: src => (
+    <div>
+      <Icon type="file" />
+      <a href={src}>{src}</a>
+    </div>
+  ),
+};
 
 function getBase64(file) {
   return new Promise((resolve, reject) => {
@@ -33,12 +49,13 @@ function disableOrHidePropsChildren(children, listType) {
 export default class UploadComponent extends React.Component {
   static defaultProps = {
     preview: true,
+    previewType: "img",
   };
 
   state = {
     fileList: this.props.value || [],
     previewVisible: false,
-    previewImage: "",
+    previewFile: "",
   };
 
   componentWillMount() {
@@ -128,15 +145,14 @@ export default class UploadComponent extends React.Component {
     if (!file.url && !file.preview) {
       file.preview = await getBase64(file.originFileObj);
     }
-
     this.setState({
-      previewImage: file.url || file.preview,
+      previewFile: file.url || file.preview,
       previewVisible: true,
     });
   };
 
   render() {
-    const { fileList, previewVisible, previewImage } = this.state;
+    const { fileList, previewVisible, previewFile } = this.state;
     const listType = this.props.preview ? this.props.listType : "text";
     return (
       <div>
@@ -159,7 +175,7 @@ export default class UploadComponent extends React.Component {
           footer={null}
           onCancel={this.handleCancel}
         >
-          <img alt="example" style={{ width: "100%" }} src={previewImage} />
+          {PREVIEW_CONTENT[this.props.previewType](previewFile)}
         </Modal>
       </div>
     );
@@ -168,4 +184,5 @@ export default class UploadComponent extends React.Component {
 
 UploadComponent.propTypes = {
   preview: PropTypes.bool,
+  previewType: PropTypes.string,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const PREVIEW_CONTENT = {
       Your browser does not support HTML5 video.
     </video>
   ),
-  img: src => <img alt="example" style={{ width: "100%" }} src={src} />,
+  image: src => <img alt="example" style={{ width: "100%" }} src={src} />,
   file: src => (
     <div>
       <Icon type="file" />
@@ -49,13 +49,13 @@ function disableOrHidePropsChildren(children, listType) {
 export default class UploadComponent extends React.Component {
   static defaultProps = {
     preview: true,
-    previewType: "img",
   };
 
   state = {
     fileList: this.props.value || [],
     previewVisible: false,
     previewFile: "",
+    previewFileType: "file",
   };
 
   componentWillMount() {
@@ -142,17 +142,30 @@ export default class UploadComponent extends React.Component {
   handleCancel = () => this.setState({ previewVisible: false });
 
   handlePreview = async file => {
+    let fileType = "file";
     if (!file.url && !file.preview) {
       file.preview = await getBase64(file.originFileObj);
     }
+    if (file.type && file.type.includes("video")) {
+      fileType = "video";
+    }
+    if (file.type && file.type.includes("image")) {
+      fileType = "image";
+    }
     this.setState({
+      previewFileType: fileType,
       previewFile: file.url || file.preview,
       previewVisible: true,
     });
   };
 
   render() {
-    const { fileList, previewVisible, previewFile } = this.state;
+    const {
+      fileList,
+      previewVisible,
+      previewFile,
+      previewFileType,
+    } = this.state;
     const listType = this.props.preview ? this.props.listType : "text";
     return (
       <div>
@@ -175,7 +188,7 @@ export default class UploadComponent extends React.Component {
           footer={null}
           onCancel={this.handleCancel}
         >
-          {PREVIEW_CONTENT[this.props.previewType](previewFile)}
+          {PREVIEW_CONTENT[previewFileType](previewFile)}
         </Modal>
       </div>
     );

--- a/stories/index.js
+++ b/stories/index.js
@@ -4,21 +4,21 @@ import { Icon } from "antd";
 
 import Upload from "../src";
 
-const cropOptions = {
-  crop: {
-    unit: "%",
-    width: 100,
-    aspect: 1,
-  },
-};
+// const cropOptions = {
+//   crop: {
+//     unit: "%",
+//     width: 100,
+//     aspect: 1,
+//   },
+// };
 // default demo
 storiesOf("Welcome", module).add("to Storybook", () => (
   <Upload
-    cropOptions={cropOptions}
-    listType="picture-card"
+    // cropOptions={cropOptions}
+    // listType="picture-card"
     maxFileNumber={1}
-    maxFileSize={700}
-    accept=".jpg, .png"
+    // maxFileSize={700}
+    accept=".jpg, .png, .mp4, .sqlite"
   >
     <Icon type="plus" />
     <div className="ant-upload-text">Upload</div>


### PR DESCRIPTION
### 对应的 #5 

Issue(#5)

### 修改内容
增加previewType 默认值为img 可选值为file、img、video
类型为video时，用video标签对预览内容作展示
类型为file时，预览内容为文件图标加文件链接

### 发布计划（选填）

上线时需要设置的环境变量或参数

如果需要修改更新线上数据的还需要提供脚本

### 其他（选填）

描述你的设计和实现，有什么亮点，以及可能存在什么坑，帮助 reviewer 更好地理解你的代码
